### PR TITLE
平行投影を実装

### DIFF
--- a/Solution/Engine/Camera/Camera.cpp
+++ b/Solution/Engine/Camera/Camera.cpp
@@ -113,12 +113,15 @@ void Camera::updateViewMatrix()
 
 void Camera::updateProjectionMatrix()
 {
-	// 透視投影による射影行列の生成
-	matProjection = XMMatrixPerspectiveFovLH(
-		fogAngleYRad,
-		aspectRatio,
-		nearZ, farZ
-	);
+	if (perspectiveProjFlag)
+	{
+		// 透視投影による射影行列の生成
+		matProjection = XMMatrixPerspectiveFovLH(fogAngleYRad, aspectRatio, nearZ, farZ);
+	} else
+	{
+		// 平行投影
+		matProjection = XMMatrixOrthographicLH(WinAPI::window_width, WinAPI::window_height, nearZ, farZ);
+	}
 }
 
 void Camera::updateMatrix()
@@ -211,7 +214,7 @@ Camera::Camera(const float window_width, const float window_height) :
 	aspectRatio(window_width / window_height),
 	fogAngleYRad(XM_PIDIV3),
 	nearZ(1.f),
-	farZ(256.f)
+	farZ(10000.f)
 {
 	//ビュー行列の計算
 	updateViewMatrix();

--- a/Solution/Engine/Camera/Camera.h
+++ b/Solution/Engine/Camera/Camera.h
@@ -51,6 +51,9 @@ private:
 	float farZ;
 	float fogAngleYRad;
 
+	// 透視投影かどうか
+	bool perspectiveProjFlag = true;
+
 	// --------------------
 	// メンバ関数
 	// --------------------
@@ -68,6 +71,8 @@ private:
 	virtual void postUpdate() {};
 
 public:
+	inline bool getPerspectiveProjFlag() const { return perspectiveProjFlag; }
+
 	/// @brief 視線ベクトル（奥方向）を取得
 	inline const XMVECTOR& getEyeVec() const { return cameraAxisZ; }
 
@@ -105,6 +110,9 @@ public:
 
 	// 注視点座標の取得
 	inline const XMFLOAT3& getTarget() const { return target; }
+
+	/// @brief 透視投影かどうかを設定
+	inline void setPerspectiveProjFlag(bool perspectiveProjFlag) { this->perspectiveProjFlag = perspectiveProjFlag; projectionDirty = true; };
 
 	// 注視点座標の設定
 	inline void setTarget(const XMFLOAT3& target) { this->target = target; viewDirty = true; }


### PR DESCRIPTION
## 概要

Cameraクラスに透視投影と平行投影を切り替える機能を追加した

## 実装理由

- Spriteにはカメラが無いため、カメラの機能を使うには3Dでビルボードを使う必要があった
- 見た目は2Dにしたいので、透視投影ではなく平行投影で描画したかった

## 内容

Cameraクラスの`perspectiveProjFlag`が`true`なら透視投影、`false`なら平行投影